### PR TITLE
fixed .gemspec

### DIFF
--- a/griddler-cloudmailin.gemspec
+++ b/griddler-cloudmailin.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Griddler::Cloudmailin::VERSION
   spec.authors       = [""]
   spec.email         = [""]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Griddler Plugin for cloudmailin}
+  spec.description   = %q{Griddler Plugin for cloudmailin email parsing service}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
Newest ruby/bundle gives error when I have this gem in Gemfile.  "Summary can't be TODO" and won't load. My update fixed this.
