### PR TITLE
Add travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
----
 language: ruby
+dist: trusty
+script: bundle exec rspec
 rvm:
-  - 2.1.9
-script:
-  - rspec
+  - 2.4.0
+  - 2.3
+  - 2.2
+  - 1.9
+  - jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
 dist: trusty
-script: bundle exec rspec
 rvm:
   - 2.4.0
   - 2.3
   - 2.2
   - 1.9
   - jruby
+
+before_install:
+  - gem update bundler
+
+script: bundle exec rspec


### PR DESCRIPTION
Adds a slightly updated travis file for #14.

However, the specs fail in Ruby 1.9 because of the rack requirement. There must be a simple way to force an older version of rack in 1.9 for testing but I don't want to do anything that might interfere with people's apps.

Will take a look and see if there's a solution.