### PR TITLE
Handle new normalized format from CloudMailin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .ruby-gemset
 .ruby-version
+.rspec
 *.gem
 *.rbc
 .bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 AllCops:
+  TargetRubyVersion: 1.9
   DisplayCopNames: true
   Exclude:
     - 'tmp/**/*'
@@ -34,11 +35,6 @@ FileName:
 LineLength:
   Max: 120
   Enabled: true
-
-Style/SymbolArray:
-  Description: 'Use %i or %I for arrays of symbols.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-i'
-  Enabled: true # Only available in Ruby 2.0+
 
 Style/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'griddler', github: 'thoughtbot/griddler' # So as to include the spec folder
+gem 'nokogiri', (RUBY_VERSION < '2' ? '< 1.7' : '> 0') # Nokogiri >= 1.7 requires Ruby 2+
 
 gemspec
 

--- a/lib/griddler/cloudmailin/adapter.rb
+++ b/lib/griddler/cloudmailin/adapter.rb
@@ -67,7 +67,7 @@ module Griddler
       end
 
       def header_keys
-        @header_keys ||= Hash[ legacy? ? KEY_LIST.map { |s| [s, s.capitalize] } : KEY_LIST.map { |s| [s, s] } ]
+        @header_keys ||= Hash[legacy? ? KEY_LIST.map { |s| [s, s.capitalize] } : KEY_LIST.map { |s| [s, s] }]
       end
 
       KEY_LIST = [:from, :to, :cc, :date, :subject].freeze

--- a/lib/griddler/cloudmailin/adapter.rb
+++ b/lib/griddler/cloudmailin/adapter.rb
@@ -67,7 +67,7 @@ module Griddler
       end
 
       def header_keys
-        @header_keys ||= legacy? ? KEY_LIST.map { |s| [s, s.capitalize] }.to_h : KEY_LIST.map { |s| [s, s] }.to_h
+        @header_keys ||= Hash[ legacy? ? KEY_LIST.map { |s| [s, s.capitalize] } : KEY_LIST.map { |s| [s, s] } ]
       end
 
       KEY_LIST = [:from, :to, :cc, :date, :subject].freeze

--- a/lib/griddler/cloudmailin/adapter.rb
+++ b/lib/griddler/cloudmailin/adapter.rb
@@ -12,6 +12,10 @@ module Griddler
         normalized_params
       end
 
+      def legacy?
+        @legacy ||= headers.key? :From
+      end
+
       private
 
       attr_reader :params
@@ -21,24 +25,27 @@ module Griddler
       end
 
       def recipients(field)
-        params[:headers][field].to_s.split(',').map(&:strip)
+        headers[field].to_s.split(',').map(&:strip)
       end
 
       def ccs
-        @ccs ||= recipients(:Cc)
+        @ccs ||= recipients(header_keys[:cc])
       end
 
       def tos
-        @tos ||= recipients(:To)
+        @tos ||= recipients(header_keys[:to])
+      end
+
+      def envelope_to
+        @envelope_to ||= params[:envelope][:to]
+      end
+
+      def header_emails
+        @header_emails ||= (tos | ccs).map { |addressee| Griddler::EmailParser.parse_address(addressee)[:email] }
       end
 
       def bcc
-        return @bcc if @bcc
-        envelope_to = params[:envelope][:to]
-        header_to_emails = (tos | ccs).map do |addressee|
-          Griddler::EmailParser.parse_address(addressee)[:email]
-        end
-        @bcc = header_to_emails.include?(envelope_to) ? [] : [envelope_to]
+        @bcc ||= header_emails.include?(envelope_to) ? [] : [envelope_to]
       end
 
       def headers
@@ -49,15 +56,21 @@ module Griddler
         @base_params ||= {
           to: tos,
           cc: ccs,
-          from: headers[:From],
-          date: headers[:Date].try(:to_datetime),
-          subject: headers[:Subject],
+          from: headers[header_keys[:from]],
+          date: headers[header_keys[:date]].try(:to_datetime),
+          subject: headers[header_keys[:subject]],
           text: params[:plain],
           html: params[:html],
           attachments: params.fetch(:attachments) { {} }.values,
           headers: headers
         }
       end
+
+      def header_keys
+        @header_keys ||= legacy? ? KEY_LIST.map { |s| [s, s.capitalize] }.to_h : KEY_LIST.map { |s| [s, s] }.to_h
+      end
+
+      KEY_LIST = [:from, :to, :cc, :date, :subject].freeze
     end
   end
 end

--- a/lib/griddler/cloudmailin/version.rb
+++ b/lib/griddler/cloudmailin/version.rb
@@ -1,5 +1,5 @@
 module Griddler
   module Cloudmailin
-    VERSION = '1.0.3'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/lib/griddler/cloudmailin/version.rb
+++ b/lib/griddler/cloudmailin/version.rb
@@ -1,5 +1,5 @@
 module Griddler
   module Cloudmailin
-    VERSION = '1.0.2'.freeze
+    VERSION = '1.0.3'.freeze
   end
 end


### PR DESCRIPTION
CloudMailin can now normalize the data it outputs so as to avoid capitalized hash keys. Example:

Current (legacy) format: `headers['From']`
Newer format (not yet the default): `headers['from']`

Because the `mail` gem creates a hash with indifferent access, both these can also be referred to using symbols, e.g. `headers[:From]` or now `headers[:from]`

CloudMailin expect the new format to become commonly used so this PR is to ensure that the gem can handle the newer format.