### PR TITLE
Deprecated griddler-cloudmailin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Deprecated as of September 19, 2024
+
+Griddler, and its related libraries, have been deprecated in favor of [ActionMailbox](https://guides.rubyonrails.org/action_mailbox_basics.html) since this is built into Rails now.
+
 # Griddler::Cloudmailin
 [![Gem Version](https://badge.fury.io/rb/griddler-cloudmailin.svg)](https://rubygems.org/gems/griddler-cloudmailin)
 [![Gem downloads](https://img.shields.io/gem/dt/griddler-cloudmailin.svg)](https://rubygems.org/gems/griddler-cloudmailin)


### PR DESCRIPTION
Griddler has been deprecated in favor of [ActionMailbox](https://guides.rubyonrails.org/action_mailbox_basics.html) since this is built into Rails now.